### PR TITLE
Move WS error message to debug log

### DIFF
--- a/plugin/lib/websocket/ws.js
+++ b/plugin/lib/websocket/ws.js
@@ -111,9 +111,8 @@ module.exports = function(app, publishDelta) {
     });
 
     ws.on('error', (error) => {
-      app.error(`[WEBSOCKET] WebSocket error: ${error.message}`);
       app.setPluginStatus(`Error: ${error.message} - ERROR`);
-      app.debug("[WEBSOCKET] WebSocket error occurred, terminating connection.");
+      app.debug(`[WEBSOCKET] WebSocket error: "${error.message}", terminating connection.`);
       clearInterval(pingInterval);
       if (ws) ws.terminate();
       if (shouldReconnect) {


### PR DESCRIPTION
If the wifi module decides to stop working, the plugin starts emitting error messages rather constantly, causing the signalk server to get bogged down and eventually freeze. The normal error messages are duplicative to the status and the debug messages anyway, so carry the risk of breaking more things. Just remove the app.error invocation and move the message to the debug log.